### PR TITLE
DEVOPS-2119: make LightGBM an installable pip package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include include *
+recursive-include src *

--- a/python-package/lightgbm/libpath.py
+++ b/python-package/lightgbm/libpath.py
@@ -14,15 +14,16 @@ def find_lib_path():
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
     dll_path = [curr_path, os.path.join(curr_path, '../../lib/'),
                 os.path.join(curr_path, '../../'),
+                os.path.join(curr_path, '../'),
                 os.path.join(curr_path, './lib/'),
                 os.path.join(sys.prefix, 'lightgbm')]
     if os.name == 'nt':
         dll_path.append(os.path.join(curr_path, '../../windows/x64/Dll/'))
         dll_path.append(os.path.join(curr_path, './windows/x64/Dll/'))
         dll_path.append(os.path.join(curr_path, '../../Release/'))
-        dll_path = [os.path.join(p, 'lib_lightgbm.dll') for p in dll_path]
+        dll_path = [os.path.join(p, 'lightgbm.dll') for p in dll_path]
     else:
-        dll_path = [os.path.join(p, 'lib_lightgbm.so') for p in dll_path]
+        dll_path = [os.path.join(p, 'lightgbm.so') for p in dll_path]
     lib_path = [p for p in dll_path if os.path.exists(p) and os.path.isfile(p)]
     if not lib_path:
         dll_path = [os.path.realpath(p) for p in dll_path]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,57 @@
+# coding: utf-8
+# pylint: disable=invalid-name, exec-used
+"""Setup lightgbm package."""
+from __future__ import absolute_import
+
+import glob
+import os
+import sys
+
+from setuptools import Extension, find_packages, setup
+
+sys.path.insert(0, '.')
+
+LIB_SOURCE_GLOBS = [
+    "src/application/*.cpp",
+    "src/boosting/*.cpp",
+    "src/io/*.cpp",
+    "src/metric/*.cpp",
+    "src/objective/*.cpp",
+    "src/network/*.cpp",
+    "src/treelearner/*.cpp",
+    "src/c_api.cpp",
+]
+LIB_SOURCES = []
+for pattern in LIB_SOURCE_GLOBS:
+    for path in glob.glob(pattern):
+        LIB_SOURCES.append(path)
+
+shared_lib = Extension(
+    'lightgbm',
+    define_macros = [('MAJOR_VERSION', '1'), ('MINOR_VERSION', '0')],
+    include_dirs = ["include"],
+    sources = LIB_SOURCES,
+)
+
+# TODO: Make this work just as well on OSX and Windows.
+shared_lib.extra_compile_args = [
+    '-pthread', '-O3', '-Wall', '-std=c++11', '-DUSE_SOCKET', '-fPIC',
+    '-Wno-unknown-pragmas',
+]
+
+setup(name='lightgbm',
+      version="20170301.1+sm1",
+      description="LightGBM Python Package",
+      install_requires=[
+          'numpy',
+          'scipy',
+      ],
+      maintainer='Sight Machine',
+      maintainer_email='ops@sightmachine.com',
+      zip_safe=False,
+      packages=find_packages("python-package"),
+      include_package_data=True,
+      ext_modules=[shared_lib],
+      package_dir={'': 'python-package'},
+      url='https://github.com/Microsoft/LightGBM',
+)


### PR DESCRIPTION
Alter setup.py to that LightGBM can be built as a pip package (at least on recent Linux systems -- more portable solution to come.)

Tested by installing and then running `python simple_example.py` in the examples/python-guide directory